### PR TITLE
support `make binary`

### DIFF
--- a/scripts/gen-builder-dockerfile.sh
+++ b/scripts/gen-builder-dockerfile.sh
@@ -81,7 +81,7 @@ EOT
 
 if [ "$tag" != "" ];then
   cat << EOT
-RUN git checkout v$tag
+RUN git fetch && git checkout v$tag
 EOT
 fi
 
@@ -98,7 +98,7 @@ EOT
 
 if [ "$tag" != "" ];then
   cat << EOT
-RUN git checkout v$tag
+RUN git fetch && git checkout v$tag
 EOT
 fi
 
@@ -114,7 +114,7 @@ EOT
 
 if [ "$tag" != "" ];then
   cat << EOT
-RUN git checkout v$tag
+RUN git fetch && git checkout v$tag
 EOT
 fi
 


### PR DESCRIPTION
### What problem does this PR solve?
- support `make binary` to generate binary files at `build/bin` directory. 
- fix some build prerequisites to support increment build

close: https://github.com/pingcap/tidb-helper/issues/6

### What is changed and how it works?
- add new build target `make binary`
- remove unnecessary directory prerequisites that cause false positive check.

### Check List
Tests
- manual build test.

Code changes

Side effects

Related changes