### PR TITLE
optimize build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ define fetch_source
 endef
 define update_source_tag
 	$(eval remote = $(shell cd $(1) && git remote -v | grep fetch | grep $(2) | cut -f1))
-    cd $(1) && git fetch $(remote) $(3) && git checkout $(3)
+	cd $(1) && git fetch $(remote) $(3) && git checkout $(3)
 endef
 
 $(BUILD_DIR):

--- a/Makefile
+++ b/Makefile
@@ -11,31 +11,41 @@ BUILD_DIR=build
 TIDB_SOURCE=$(BUILD_DIR)/$(PROJECT_TIDB)
 TIKV_SOURCE=$(BUILD_DIR)/$(PROJECT_TIKV)
 PD_SOURCE=$(BUILD_DIR)/$(PROJECT_PD)
-ARTIFACT_BINARY=$(BUILD_DIR)/bin/$(TAG)
+BINARY_DIR=$(BUILD_DIR)/bin
+ARTIFACT_BINARY=$(BINARY_DIR)/$(TAG)
 ARTIFACT_DIR=$(BUILD_DIR)/dist
-ARTIFACT_DOCKER=${ARTIFACT_DIR}/tidb-docker-$(TAG).tar.gz
+DOCKER_IMAGE_NAME=tidb-docker
+DOCKER_IMAGE_TAG=$(ORG_PINGCAP)/$(DOCKER_IMAGE_NAME):$(TAG)
+ARTIFACT_DOCKER=${ARTIFACT_DIR}/$(DOCKER_IMAGE_NAME)-$(TAG).tar.gz
 ARTIFACT_PACKAGE=$(ARTIFACT_DIR)/tidb-pkg
-ARTIFACT_RPM=${ARTIFACT_DIR}/
-DOCKER_IMAGE_NAME=pingcap/tidb:$(TAG)
+BUILDER_PREFIX=tidb-builder
+BUILDER_IMAGE_BINARY=$(ORG_PINGCAP)/$(BUILDER_PREFIX)-binary
+BUILDER_IMAGE_RPM=$(ORG_PINGCAP)/$(BUILDER_PREFIX)-rpm
+BUILDER_IMAGE_DEB=$(ORG_PINGCAP)/$(BUILDER_PREFIX)-deb
 
 define fetch_source
-	mkdir -p $(1)
 	@if [ ! -d $(1)/.git ]; then\
+		mkdir -p $(1); \
 		git clone $(2).git $(1); \
 	fi
+endef
+define update_source_tag
+	$(eval remote = $(shell cd $(1) && git remote -v | grep fetch | grep $(2) | cut -f1))
+    cd $(1) && git fetch $(remote) $(3) && git checkout $(3)
 endef
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
+.PHONY: TIDB_SOURCE TIKV_SOURCE PD_SOURCE
 # don't use directory so we can force update the projects each time.
-$(TIDB_SOURCE):
+TIDB_SOURCE:
 	$(call fetch_source, $(TIDB_SOURCE),$(GIT_URL_TIDB))
 
-$(TIKV_SOURCE):
+TIKV_SOURCE:
 	$(call fetch_source, $(TIKV_SOURCE),$(GIT_URL_TIKV))
 
-$(PD_SOURCE):
+PD_SOURCE:
 	$(call fetch_source, $(PD_SOURCE),$(GIT_URL_PD))
 
 .PHONY: check
@@ -45,32 +55,46 @@ ifndef TAG
 endif
 
 .PHONY: source
-source: $(TIDB_SOURCE) $(TIKV_SOURCE) $(PD_SOURCE)
+source: TIDB_SOURCE TIKV_SOURCE PD_SOURCE
 
 .PHONY: binary
-binary: check $(ARTIFACT_BINARY)
+binary: build-prepare $(ARTIFACT_BINARY)
 
-$(ARTIFACT_BINARY): $(ARTIFACT_DOCKER)
-	mkdir -p ${ARTIFACT_BINARY}
-	docker load -i ${ARTIFACT_DOCKER}
-	docker run --rm \
-		--entrypoint=/bin/cp \
+$(ARTIFACT_BINARY):
+# checkout and update source code here
+ifdef TAG
+	$(call update_source_tag, $(TIDB_SOURCE),$(GIT_URL_TIDB), v$(TAG))
+	$(call update_source_tag, $(TIKV_SOURCE),$(GIT_URL_TIKV), v$(TAG))
+	$(call update_source_tag, $(PD_SOURCE),$(GIT_URL_PD), v$(TAG))
+endif
+	docker run \
+		-v $(shell realpath $(TIDB_SOURCE)):/build/tidb \
+		-v $(shell realpath $(TIKV_SOURCE)):/build/tikv \
+		-v $(shell realpath $(PD_SOURCE)):/build/pd \
+		-v $(CURDIR)/scripts/build.sh:/build.sh \
 		-v $(CURDIR)/${ARTIFACT_BINARY}:/out \
-		${DOCKER_IMAGE_NAME} \
-		/tidb-server /tikv-server /tikv-ctl /pd-server /pd-ctl /pd-recover /out
+		$(BUILDER_IMAGE_BINARY) /build.sh
 
-$(ARTIFACT_DOCKER): $(TIDB_SOURCE) $(TIKV_SOURCE) $(PD_SOURCE)
+$(ARTIFACT_DOCKER): source docker-builder $(ARTIFACT_BINARY)
 	mkdir -p $(ARTIFACT_DIR)
-	bash ./scripts/gen-builder-dockerfile.sh $(TAG) | docker build -t ${DOCKER_IMAGE_NAME} -f - .
-	docker save ${DOCKER_IMAGE_NAME} | gzip > ${ARTIFACT_DOCKER}
+	bash ./scripts/gen-image-dockerfile.sh $(TAG) | docker build -t ${DOCKER_IMAGE_TAG} -f - .
+	docker save ${DOCKER_IMAGE_TAG} | gzip > ${ARTIFACT_DOCKER}
 
-.PHONY: docker
+.PHONY: docker docker-builer build-prepare
+build-prepare: check source docker-builder
 docker: check source $(ARTIFACT_DOCKER)
 
-.PHONY: rpm
-rpm: check $(ARTIFACT_BINARY)
+docker-builder:
+ifeq ($(shell docker images -q $(BUILDER_IMAGE_BINARY)),)
+	bash ./scripts/gen-builder.sh $(shell cat $(TIKV_SOURCE)/rust-toolchain) | docker build -t $(BUILDER_IMAGE_BINARY) -f - .
+endif
+
+.PHONY: rpm deb
+rpm: build-prepare $(ARTIFACT_BINARY)
+ifeq ($(shell docker images -q $(BUILDER_IMAGE_RPM)),)
+	docker build -t $(BUILDER_IMAGE_RPM) -f etc/dockerfile/builder-rpm.dockerfile .
+endif
 	bash scripts/gen-rpm-spec.sh $(TAG) > ${ARTIFACT_DIR}/rpm-spec
-	docker build -t tidb-rpm-builder:${TAG} -f etc/dockerfile/builder-rpm.dockerfile .
 	docker run \
 		--rm \
 		-v $(CURDIR)/${ARTIFACT_BINARY}:/root/rpmbuild/SOURCES/bin \
@@ -82,7 +106,7 @@ rpm: check $(ARTIFACT_BINARY)
 		-v $(CURDIR)/build/tidb/README.md:/root/rpmbuild/BUILD/README.md \
 		-v $(CURDIR)/${ARTIFACT_DIR}/rpm-spec:/root/rpmbuild/SPECS/tidb.spec \
 		-v $(CURDIR)/${ARTIFACT_DIR}:/root/rpmbuild/RPMS/x86_64/ \
-		tidb-rpm-builder:${TAG} rpmbuild -bb /root/rpmbuild/SPECS/tidb.spec
+		$(BUILDER_IMAGE_RPM) rpmbuild -bb /root/rpmbuild/SPECS/tidb.spec
 	rm ${ARTIFACT_DIR}/rpm-spec
 
 $(ARTIFACT_PACKAGE): $(ARTIFACT_BINARY)
@@ -99,16 +123,18 @@ $(ARTIFACT_PACKAGE): $(ARTIFACT_BINARY)
 	install -D -m 0644 etc/service/tikv-server.service ${ARTIFACT_PACKAGE}/usr/lib/systemd/system/tikv.service
 	install -D -m 0644 etc/service/pd-server.service ${ARTIFACT_PACKAGE}/usr/lib/systemd/system/pd.service
 	mkdir -p ${ARTIFACT_PACKAGE}/var/lib/tikv ${ARTIFACT_PACKAGE}/var/lib/tikv ${ARTIFACT_PACKAGE}/var/lib/pd
-.PHONY: deb
-deb: check $(ARTIFACT_PACKAGE)
+
+deb: build-prepare $(ARTIFACT_PACKAGE)
+ifeq ($(shell docker images -q $(BUILDER_IMAGE_DEB)),)
+	docker build -t $(BUILDER_IMAGE_DEB) -f etc/dockerfile/builder-deb.dockerfile scripts
+endif
 	bash scripts/gen-deb-control.sh $(TAG) | install -D /dev/stdin ${ARTIFACT_PACKAGE}/DEBIAN/control
 	install -D -m 0755 etc/deb/preinst ${ARTIFACT_PACKAGE}/DEBIAN/preinst
 	install -D -m 0755 etc/deb/preinst ${ARTIFACT_PACKAGE}/DEBIAN/postinst
-	docker build -t tidb-deb-builder:${TAG} -f etc/dockerfile/builder-deb.dockerfile scripts
 	docker run \
 		--rm \
 		-v $(CURDIR)/${BUILD_DIR}:/build \
-		tidb-deb-builder:${TAG} fakeroot dpkg-deb --build ${ARTIFACT_PACKAGE} /build/dist
+		$(BUILDER_IMAGE_DEB) fakeroot dpkg-deb --build ${ARTIFACT_PACKAGE} /build/dist
 	rm -rf ${ARTIFACT_PACKAGE}
 
 .PHONY: clean-dist clean-bin clean
@@ -116,7 +142,7 @@ clean-dist:
 	rm -rf build/dist
 
 clean-bin:
-	rm -rf build/bin
+	rm -rf build/bin/$(TAG)
 
 clean:
 	rm -rf build

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+cd /build/tidb && make 
+cd /build/pd && make
+cd /build/tidb && make dist_release
+
+cd /build/tidb/bin && cp tidb-server /out
+cd /build/tikv/bin && cp tikv-server tikv-ctl /out
+cd /build/pd/bin && cp pd-server pd-ctl pd-recover /out

--- a/scripts/gen-image-dockerfile.sh
+++ b/scripts/gen-image-dockerfile.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+tag=
+if [ "$#" -ge "1" ];then
+    tag="$1"
+fi
+
+# Export to a clean image
+cat <<EOT
+FROM pingcap/alpine-glibc
+COPY build/bin/$tag/* /
+
+EXPOSE 20160 20180
+
+ENTRYPOINT ["/tidb-server"]
+EOT


### PR DESCRIPTION
### What problem does this PR solve?
optimize make progress by:
- reuse docker image for build binary/rpm/deb instead always create one
- support custom source directory for tidb/tikv/pd, so we can run `make binary TAG=3.0.7 TIDB_SOURCE=/path/to/tidb TIKV_SOURCE=/path/to/tikv PD_SOURCE=...`
- add version info to binary file path, so we can depend on binary path to build docker/rpm/deb more safe

### What is changed and how it works?
- add new build target `make binary`
- remove unnecessary directory prerequisites that cause false positive check.

### Check List
Tests
- manual build test.

Code changes

Side effects

Related changes