### PR TITLE
set tikv-server  default `LimitNOFILE` to 100000

### DIFF
--- a/etc/service/tikv-server.service
+++ b/etc/service/tikv-server.service
@@ -9,7 +9,7 @@ ExecStart=/usr/bin/tikv-server --config /etc/tikv/config.toml
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 KillSignal=SIGINT
-LimitNOFILE=1024
+LimitNOFILE=100000
 WorkingDirectory=/var/lib/tikv/
 
 [Install]


### PR DESCRIPTION
in a real TiDB cluster running in production, tikv-server need at least 82910 num-of-files to work properly. So we set `LimitNOFILE=100000` in `tikv-server.service` to ensure with default configuration, TiDB cluster can funciton well