### PR TITLE
DNM: support build local

### DIFF
--- a/scripts/build-tidb.sh
+++ b/scripts/build-tidb.sh
@@ -6,20 +6,30 @@ GOPATH=$(go env GOPATH)
 
 set -e
 
-cd /build/tidb && make
-cd /build/tidb-ctl && make
-cd /build/pd && make
-
-if [ "$(uname -m)" = "aarch64" ];then
-    cd /build/tikv && ROCKSDB_SYS_SSE=0 make dist_release
-else
-    cd /build/tikv && make dist_release
+if [ "$SOURCE_DIR" == "" ] || [ ! -d $SOURCE_DIR ]; then
+  echo SOURCE_DIR not exist or is not a directory
+  exit 1
 fi
 
-cd /build/tidb-binlog && GOPATH=$GOPATH make
+if [ "$TARGET_DIR" == "" ] || [ ! -d $TARGET_DIR ]; then
+  echo TARGET_DIR not exist or is not a directory
+  exit 1
+fi
 
-cd /build/tidb/bin && cp tidb-server /out
-cp /build/tidb-ctl/tidb-ctl /out
-cd /build/tikv/bin && cp tikv-server tikv-ctl /out
-cd /build/pd/bin && cp pd-server pd-ctl pd-recover /out
-cd /build/tidb-binlog/bin && cp arbiter binlogctl drainer pump reparo /out
+cd $SOURCE_DIR/tidb && make
+cd $SOURCE_DIR/tidb-ctl && make
+cd $SOURCE_DIR/pd && make
+
+if [ "$(uname -m)" = "aarch64" ];then
+    cd $SOURCE_DIR/tikv && ROCKSDB_SYS_SSE=0 make dist_release
+else
+    cd $SOURCE_DIR/tikv && make dist_release
+fi
+
+cd $SOURCE_DIR/tidb-binlog && GOPATH=$GOPATH make
+
+cd $SOURCE_DIR/tidb/bin && cp tidb-server $TARGET_DIR
+cp $SOURCE_DIR/tidb-ctl/tidb-ctl $TARGET_DIR
+cd $SOURCE_DIR/tikv/bin && cp tikv-server tikv-ctl $TARGET_DIR
+cd $SOURCE_DIR/pd/bin && cp pd-server pd-ctl pd-recover $TARGET_DIR
+cd $SOURCE_DIR/tidb-binlog/bin && cp arbiter binlogctl drainer pump reparo $TARGET_DIR

--- a/scripts/build-toolkit.sh
+++ b/scripts/build-toolkit.sh
@@ -2,12 +2,22 @@
 
 set -e
 
-cd /build/pd && make
-cd /build/importer && make release
-cd /build/tidb-lightning && make
-cd /build/tidb-tools && make build
+if [ "$SOURCE_DIR" == "" ] || [ ! -d $SOURCE_DIR ]; then
+  echo SOURCE_DIR not exist or is not a directory
+  exit 1
+fi
 
-cp /build/pd/bin/pd-tso-bench /out
-cd /build/tidb-lightning/bin && cp tidb-lightning tidb-lightning-ctl /out
-cp /build/tidb-tools/bin/sync_diff_inspector  /out
-cp /build/importer/target/release/tikv-importer /out
+if [ "$TARGET_DIR" == "" ] || [ ! -d $TARGET_DIR ]; then
+  echo TARGET_DIR not exist or is not a directory
+  exit 1
+fi
+
+cd $SOURCE_DIR/pd && make
+cd $SOURCE_DIR/importer && make release
+cd $SOURCE_DIR/tidb-lightning && make
+cd $SOURCE_DIR/tidb-tools && make build
+
+cp $SOURCE_DIR/pd/bin/pd-tso-bench $TARGET_DIR
+cd $SOURCE_DIR/tidb-lightning/bin && cp tidb-lightning tidb-lightning-ctl $TARGET_DIR
+cp $SOURCE_DIR/tidb-tools/bin/sync_diff_inspector  $TARGET_DIR
+cp $SOURCE_DIR/importer/target/release/tikv-importer $TARGET_DIR


### PR DESCRIPTION
Usage: `make binary TAG=v3.1.0 BUILD_MODE=local`

`BUILD_MODE=local` set this param will build binary/rpm at localhost. if not set or set `BUILD_MODE=docker`, will build in docker as before.

NOTE: currently don't support build deb at localhost, will support later if needed.